### PR TITLE
Fix link to LangChain documentation

### DIFF
--- a/chatapi/ChatAPI + LangChain Basics.ipynb
+++ b/chatapi/ChatAPI + LangChain Basics.ipynb
@@ -5,7 +5,7 @@
    "id": "e2376f66",
    "metadata": {},
    "source": [
-    "[Official documentation on chat from LangChain](https://langchain.readthedocs.io/en/latest/modules/chat/getting_started.html)"
+    "[Official documentation on chat from LangChain](https://python.langchain.com/en/latest/modules/models/chat/getting_started.html)"
    ]
   },
   {


### PR DESCRIPTION
Current link returns a 404 error so have updated it to the equivalent page in the LangChain Python docs.