### PR TITLE
Fix variable name called by print() function

### DIFF
--- a/data_generation/Exploring ChatGPT Function Calling.ipynb
+++ b/data_generation/Exploring ChatGPT Function Calling.ipynb
@@ -174,7 +174,7 @@
    ],
    "source": [
     "ai_response_message = response[\"choices\"][0][\"message\"]\n",
-    "print(message)"
+    "print(ai_response_message)"
    ]
   },
   {


### PR DESCRIPTION
Changed 'message' to 'ai_response_message'.