### PR TITLE
Update Quickstart Guide.ipynb

### DIFF
--- a/getting_started/Quickstart Guide.ipynb
+++ b/getting_started/Quickstart Guide.ipynb
@@ -364,7 +364,7 @@
    "id": "45f2cf54",
    "metadata": {},
    "source": [
-    "See list of agents types [here](https://langchain.readthedocs.io/en/latest/modules/agents/agents.html?highlight=zero-shot-react-description)"
+    "See list of agents types [here](https://python.langchain.com/docs/modules/agents/agent_types/)"
    ]
   },
   {


### PR DESCRIPTION
The Link https://langchain.readthedocs.io/en/latest/modules/agents/agents.html?highlight=zero-shot-react-description "See list of agents types here" is dead. Replaced it with:
https://python.langchain.com/docs/modules/agents/agent_types/