### PR TITLE
Update LangChain Cookbook Part 1 - Fundamentals.ipynb

### DIFF
--- a/LangChain Cookbook Part 1 - Fundamentals.ipynb
+++ b/LangChain Cookbook Part 1 - Fundamentals.ipynb
@@ -492,7 +492,7 @@
     "### **Example Selectors**\n",
     "An easy way to select from a series of examples that allow you to dynamic place in-context information into your prompt. Often used when your task is nuanced or you have a large list of examples.\n",
     "\n",
-    "Check out different types of example selectors [here](https://python.langchain.com/en/latest/modules/prompts/example_selectors.html)\n",
+    "Check out different types of example selectors [here](https://python.langchain.com/docs/modules/model_io/prompts/example_selectors/)\n",
     "\n",
     "If you want an overview on why examples are important (prompt engineering), check out [this video](https://www.youtube.com/watch?v=dOxUroR57xs)"
    ]


### PR DESCRIPTION
Updated broken URL in the "Example Selectors" example to the correct python docs.