### PR TITLE
Update LangChain Cookbook Part 1 - Fundamentals.ipynb fixing agents url

### DIFF
--- a/LangChain Cookbook Part 1 - Fundamentals.ipynb
+++ b/LangChain Cookbook Part 1 - Fundamentals.ipynb
@@ -1573,7 +1573,7 @@
     "\n",
     "The language model that drives decision making.\n",
     "\n",
-    "More specifically, an agent takes in an input and returns a response corresponding to an action to take along with an action input. You can see different types of agents (which are better for different use cases) [here](https://python.langchain.com/en/latest/modules/agents/agents/agent_types.html)."
+    "More specifically, an agent takes in an input and returns a response corresponding to an action to take along with an action input. You can see different types of agents (which are better for different use cases) [here](https://python.langchain.com/en/latest/modules/agents/agent_types.html)."
    ]
   },
   {


### PR DESCRIPTION
The LangChain Cookbook Part 1 URL on the agents section was pointing to a dead page, because of the double 'agents' term in the URL. I just removed one. 