### PR TITLE
Update Expert Structured Output (Using Kor).ipynb

### DIFF
--- a/data_generation/Expert Structured Output (Using Kor).ipynb
+++ b/data_generation/Expert Structured Output (Using Kor).ipynb
@@ -1129,7 +1129,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/data_generation/Expert Structured Output (Using Kor).ipynb
+++ b/data_generation/Expert Structured Output (Using Kor).ipynb
@@ -187,7 +187,7 @@
     "    My sister's name is Rachel.\n",
     "    My brother's name Joe. My dog's name is Spot\n",
     "\"\"\"\n",
-    "output = chain.predict_and_parse(text=(text))[\"data\"]\n",
+    "output = chain.run(text=(text))[\"data\"]\n",
     "\n",
     "printOutput(output)\n",
     "# Notice how there isn't \"spot\" in the results list because it's the name of a dog, not a person."
@@ -218,7 +218,7 @@
     }
    ],
    "source": [
-    "output = chain.predict_and_parse(text=(\"The dog went to the park\"))[\"data\"]\n",
+    "output = chain.run(text=(\"The dog went to the park\"))[\"data\"]\n",
     "printOutput(output)"
    ]
   },
@@ -300,7 +300,7 @@
     "text=\"Palm trees are brown with a 6 rating. Sequoia trees are green\"\n",
     "\n",
     "chain = create_extraction_chain(llm, plant_schema)\n",
-    "output = chain.predict_and_parse(text=text)['data']\n",
+    "output = chain.run(text=text)['data']\n",
     "\n",
     "printOutput(output)"
    ]
@@ -402,7 +402,7 @@
     "\n",
     "# Changed the encoder to json\n",
     "chain = create_extraction_chain(llm, cars_schema, encoder_or_encoder_class=\"json\")\n",
-    "output = chain.predict_and_parse(text=text)['data']\n",
+    "output = chain.run(text=text)['data']\n",
     "\n",
     "printOutput(output)"
    ]
@@ -529,7 +529,7 @@
    ],
    "source": [
     "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class='json')\n",
-    "output = chain.predict_and_parse(text=\"please add 15 more units sold to 2023\")['data']\n",
+    "output = chain.run(text=\"please add 15 more units sold to 2023\")['data']\n",
     "\n",
     "printOutput(output)"
    ]
@@ -891,7 +891,7 @@
     }
    ],
    "source": [
-    "output = chain.predict_and_parse(text=text)[\"data\"]\n",
+    "output = chain.run(text=text)[\"data\"]\n",
     "\n",
     "printOutput(output)"
    ]
@@ -1027,7 +1027,7 @@
    ],
    "source": [
     "chain = create_extraction_chain(llm, salary_range)\n",
-    "output = chain.predict_and_parse(text=text)[\"data\"]\n",
+    "output = chain.run(text=text)[\"data\"]\n",
     "\n",
     "printOutput(output)"
    ]
@@ -1070,7 +1070,7 @@
    ],
    "source": [
     "with get_openai_callback() as cb:\n",
-    "    result = chain.predict_and_parse(text=text)\n",
+    "    result = chain.run(text=text)\n",
     "    print(f\"Total Tokens: {cb.total_tokens}\")\n",
     "    print(f\"Prompt Tokens: {cb.prompt_tokens}\")\n",
     "    print(f\"Completion Tokens: {cb.completion_tokens}\")\n",
@@ -1129,7 +1129,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix the deprecated `predict_and_parse` with `run` when calling kor, to avoid TypeError. This issue had been fixed in kor at https://github.com/eyurtsev/kor/issues/196 