### PR TITLE
Cookbook - import ChatOpenAPI to make also this section run by its own

### DIFF
--- a/LangChain Cookbook Part 1 - Fundamentals.ipynb
+++ b/LangChain Cookbook Part 1 - Fundamentals.ipynb
@@ -1035,6 +1035,7 @@
    ],
    "source": [
     "from langchain.chains.openai_functions import create_structured_output_chain\n",
+    "from langchain.chat_models import ChatOpenAI\n",
     "\n",
     "llm = ChatOpenAI(model='gpt-4-0613', openai_api_key=openai_api_key)\n",
     "\n",


### PR DESCRIPTION
Notebook runs from top to bottom, but to make the section "Output Parsers Method 2: OpenAI Functions" run on its own without relying on imports in other sections, `ChatOpenAI` also needs to be imported.