### PR TITLE
fix: Update broken hyperlink

### DIFF
--- a/LangChain Cookbook Part 1 - Fundamentals.ipynb
+++ b/LangChain Cookbook Part 1 - Fundamentals.ipynb
@@ -1668,7 +1668,7 @@
     "\n",
     "We'll keep it towards the Chat Message use case. This would be used for chat bots.\n",
     "\n",
-    "There are many types of memory, explore [the documentation](https://python.langchain.com/en/latest/modules/memory/how_to_guides.html) to see which one fits your use case."
+    "There are many types of memory, explore [the documentation](https://python.langchain.com/docs/modules/memory/multiple_memory/) to see which one fits your use case."
    ]
   },
   {
@@ -1868,10 +1868,10 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new SimpleSequentialChain chain...\u001b[0m\n",
-      "\u001b[36;1m\u001b[1;3m\n",
-      "A classic dish from Rome is Spaghetti alla Carbonara, featuring egg, Parmesan cheese, black pepper, and pancetta or guanciale.\u001b[0m\n",
-      "\u001b[33;1m\u001b[1;3m\n",
+      "\u001B[1m> Entering new SimpleSequentialChain chain...\u001B[0m\n",
+      "\u001B[36;1m\u001B[1;3m\n",
+      "A classic dish from Rome is Spaghetti alla Carbonara, featuring egg, Parmesan cheese, black pepper, and pancetta or guanciale.\u001B[0m\n",
+      "\u001B[33;1m\u001B[1;3m\n",
       "Ingredients:\n",
       "- 8oz spaghetti \n",
       "- 4 tablespoons olive oil\n",
@@ -1887,9 +1887,9 @@
       "2. Meanwhile, add the olive oil to a large skillet over medium-high heat. Add the diced pancetta and garlic, and cook until pancetta is browned and garlic is fragrant.\n",
       "3. In a medium bowl, whisk together the eggs, parsley, Parmesan, and salt and pepper.\n",
       "4. Drain the cooked spaghetti and add it to the skillet with the pancetta and garlic. Remove from heat and pour the egg mixture over the spaghetti, stirring to combine. \n",
-      "5. Serve the spaghetti alla carbonara with additional Parmesan cheese and black pepper.\u001b[0m\n",
+      "5. Serve the spaghetti alla carbonara with additional Parmesan cheese and black pepper.\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     }
    ],
@@ -1919,12 +1919,12 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new MapReduceDocumentsChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new MapReduceDocumentsChain chain...\u001B[0m\n",
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mWrite a concise summary of the following:\n",
+      "\u001B[32;1m\u001B[1;3mWrite a concise summary of the following:\n",
       "\n",
       "\n",
       "\"January 2017Because biographies of famous scientists tend to \n",
@@ -1942,9 +1942,9 @@
       "crazy.But maybe there is a simpler explanation. Maybe\"\n",
       "\n",
       "\n",
-      "CONCISE SUMMARY:\u001b[0m\n",
+      "CONCISE SUMMARY:\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mWrite a concise summary of the following:\n",
+      "\u001B[32;1m\u001B[1;3mWrite a concise summary of the following:\n",
       "\n",
       "\n",
       "\"the smartness and the craziness were not as separate\n",
@@ -1961,14 +1961,14 @@
       "they were all risky.\"\n",
       "\n",
       "\n",
-      "CONCISE SUMMARY:\u001b[0m\n",
+      "CONCISE SUMMARY:\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "\u001B[1m> Finished chain.\u001B[0m\n",
       "\n",
       "\n",
-      "\u001b[1m> Entering new LLMChain chain...\u001b[0m\n",
+      "\u001B[1m> Entering new LLMChain chain...\u001B[0m\n",
       "Prompt after formatting:\n",
-      "\u001b[32;1m\u001b[1;3mWrite a concise summary of the following:\n",
+      "\u001B[32;1m\u001B[1;3mWrite a concise summary of the following:\n",
       "\n",
       "\n",
       "\" Biographies of famous scientists often edit out their mistakes, giving readers the wrong impression that they never faced any risks to achieve successful results. An example of this is Newton, whose smartness is assumed to have led straight him to truths without any detours into alchemy or theology - despite the fact that he spent a lot of time on both fields. Maybe the simpler explanation is that he was willing to take risks, even if it means potentially making mistakes.\n",
@@ -1976,11 +1976,11 @@
       " In the 17th century, Newton took a risk and made three bets, one of which turned out to be a successful invention of what we now call physics. The other two bets were on less popular subjects of the time such as alchemy and theology. People did not know then what the payoff would be, but the bets still seemed relatively promising.\"\n",
       "\n",
       "\n",
-      "CONCISE SUMMARY:\u001b[0m\n",
+      "CONCISE SUMMARY:\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "\u001B[1m> Finished chain.\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     },
     {
@@ -2122,19 +2122,19 @@
      "text": [
       "\n",
       "\n",
-      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n",
-      "\u001b[32;1m\u001b[1;3m I should try to find out what band Natalie Bergman is a part of.\n",
+      "\u001B[1m> Entering new AgentExecutor chain...\u001B[0m\n",
+      "\u001B[32;1m\u001B[1;3m I should try to find out what band Natalie Bergman is a part of.\n",
       "Action: Search\n",
-      "Action Input: \"Natalie Bergman band\"\u001b[0m\n",
-      "Observation: \u001b[36;1m\u001b[1;3m['Natalie Bergman is an American singer-songwriter. She is one half of the duo Wild Belle, along with her brother Elliot Bergman. Her debut solo album, Mercy, was released on Third Man Records on May 7, 2021. She is based in Los Angeles.', 'Natalie Bergman type: American singer-songwriter.', 'Natalie Bergman main_tab_text: Overview.', 'Natalie Bergman kgmid: /m/0qgx4kh.', 'Natalie Bergman genre: Folk.', 'Natalie Bergman parents: Susan Bergman, Judson Bergman.', 'Natalie Bergman born: 1988 or 1989 (age 34–35).', 'Natalie Bergman is an American singer-songwriter. She is one half of the duo Wild Belle, along with her brother Elliot Bergman. Her debut solo album, Mercy, ...']\u001b[0m\n",
-      "Thought:\u001b[32;1m\u001b[1;3m I should search for the first album of Wild Belle\n",
+      "Action Input: \"Natalie Bergman band\"\u001B[0m\n",
+      "Observation: \u001B[36;1m\u001B[1;3m['Natalie Bergman is an American singer-songwriter. She is one half of the duo Wild Belle, along with her brother Elliot Bergman. Her debut solo album, Mercy, was released on Third Man Records on May 7, 2021. She is based in Los Angeles.', 'Natalie Bergman type: American singer-songwriter.', 'Natalie Bergman main_tab_text: Overview.', 'Natalie Bergman kgmid: /m/0qgx4kh.', 'Natalie Bergman genre: Folk.', 'Natalie Bergman parents: Susan Bergman, Judson Bergman.', 'Natalie Bergman born: 1988 or 1989 (age 34–35).', 'Natalie Bergman is an American singer-songwriter. She is one half of the duo Wild Belle, along with her brother Elliot Bergman. Her debut solo album, Mercy, ...']\u001B[0m\n",
+      "Thought:\u001B[32;1m\u001B[1;3m I should search for the first album of Wild Belle\n",
       "Action: Search\n",
-      "Action Input: \"Wild Belle first album\"\u001b[0m\n",
-      "Observation: \u001b[36;1m\u001b[1;3mIsles\u001b[0m\n",
-      "Thought:\u001b[32;1m\u001b[1;3m I now know the final answer\n",
-      "Final Answer: Isles is the first album of the band that Natalie Bergman is a part of.\u001b[0m\n",
+      "Action Input: \"Wild Belle first album\"\u001B[0m\n",
+      "Observation: \u001B[36;1m\u001B[1;3mIsles\u001B[0m\n",
+      "Thought:\u001B[32;1m\u001B[1;3m I now know the final answer\n",
+      "Final Answer: Isles is the first album of the band that Natalie Bergman is a part of.\u001B[0m\n",
       "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
+      "\u001B[1m> Finished chain.\u001B[0m\n"
      ]
     }
    ],


### PR DESCRIPTION
Updates to the Langchain official documentation have caused the original hyperlink to result in a 404 page not found error, necessitating this PR. 